### PR TITLE
Add silent for avoid message

### DIFF
--- a/autoload/gofmt.vim
+++ b/autoload/gofmt.vim
@@ -64,7 +64,7 @@ function! s:handler._on_exit(job, exit_status) abort
   if b:changedtick != self.changedtick
     return s:fmt(self.formatter)
   endif
-  :% delete
+  :silent % delete
   call setline(1, readfile(self.tmpfile))
   call winrestview(self.winsaveview)
   if has_key(self.formatter, 'next')


### PR DESCRIPTION
Currently execute `:Fmt` and move cursor,
Vim shows `--No lines in buffer--`.

This PR will fix not to show `--No lines in buffer--`.